### PR TITLE
Clarify downloader behavior and refresh personal tagger docs

### DIFF
--- a/docs/personal-tagger-architecture-overview.md
+++ b/docs/personal-tagger-architecture-overview.md
@@ -53,12 +53,13 @@ pyproject.toml defaults → Environment variables → CLI arguments
 **Key Components**:
 - `StagePrompt`: Individual prompt templates with token limits and context variables
 - `TaggerPromptProfile`: Contains prompts for all three stages (caption, keywords, description)
-- Built-in profiles: "default" and "narrative_v2" with different tone/style approaches
+- Built-in profiles: "default", "narrative_v2", and "phototools_prompt" with distinct tone/style approaches
 - Template rendering with dynamic context substitution
 
 **Prompt Profiles**:
 - **Default**: Concise, factual outputs optimized for metadata fields
 - **Narrative v2**: More evocative, storyteller tone with broader keyword diversity
+- **PhotoTools Prompt**: PhotoTools-inspired phrasing with expert keyword emphasis
 
 #### `inference.py` - AI Orchestration
 **Purpose**: Manages the complete AI inference pipeline with multiple backend support.
@@ -67,7 +68,8 @@ pyproject.toml defaults → Environment variables → CLI arguments
 - `OpenAIChatClient`: Thin wrapper around VLM backends with unified interface
 - `BaseInferenceEngine`: Abstract interface for different inference approaches
 - `OpenAIInferenceEngine`: Sequential 3-stage pipeline implementation
-- Robust error handling with per-stage fallbacks and recovery
+- `FakeInferenceEngine`: Generates deterministic fixtures when `dry_run` mode is enabled
+- `create_inference_engine()`: Factory that chooses between real and fake engines
 - Base64 image encoding and intelligent JSON response parsing
 
 **Processing Flow**:
@@ -112,9 +114,9 @@ pyproject.toml defaults → Environment variables → CLI arguments
 
 **Responsibilities**:
 - **Image discovery**: Recursive directory scanning with extension filtering
-- **Processing coordination**: Sequential image processing with progress tracking
+- **Processing coordination**: Sequential image handling via the configured inference engine
 - **Output generation**: JSONL audit logs and human-readable Markdown summaries
-- **Error aggregation**: Collects and reports processing failures
+- **Result annotation**: Captures metadata write outcomes and attaches notes per image
 - **Dual testing modes**:
   - **Dry-run**: Uses fake test data, no AI inference, no metadata writes
   - **No-meta**: Real AI inference but skips metadata writes
@@ -147,9 +149,9 @@ pyproject.toml defaults → Environment variables → CLI arguments
 
 **Features**:
 - OpenAI-compatible API standardization
-- Health checking and error recovery
-- Configurable timeouts and retry logic
-- Backend-specific optimizations
+- Health checking with graceful error reporting
+- Configurable request timeouts
+- Backend-specific extensions (e.g. LMDeploy health endpoints, Triton stub)
 
 #### Prompt Library System (`prompting/`)
 **Purpose**: Reusable prompt management infrastructure shared across ImageWorks apps.

--- a/src/imageworks/tools/model_downloader/cli.py
+++ b/src/imageworks/tools/model_downloader/cli.py
@@ -36,10 +36,13 @@ def download_model(
         None,
         "--format",
         "-f",
-        help="Preferred format (gguf, awq, gptq, safetensors, etc.)",
+        help="Preferred format(s) (comma separated: gguf, awq, gptq, safetensors, etc.)",
     ),
     location: Optional[str] = typer.Option(
-        None, "--location", "-l", help="Target location (linux_wsl, windows_lmstudio)"
+        None,
+        "--location",
+        "-l",
+        help="Target location (linux_wsl, windows_lmstudio, or custom path)",
     ),
     include_optional: bool = typer.Option(
         False,
@@ -59,10 +62,14 @@ def download_model(
     try:
         downloader = ModelDownloader()
 
+        preferred_formats = None
+        if format_preference:
+            preferred_formats = [fmt.strip() for fmt in format_preference.split(",") if fmt.strip()]
+
         # Run download directly, let aria2c show its native progress
         model_entry = downloader.download(
             model_identifier=model,
-            format_preference=format_preference,
+            format_preference=preferred_formats,
             location_override=location,
             include_optional=include_optional,
             force_redownload=force,
@@ -108,7 +115,9 @@ def list_models(
 
     try:
         downloader = ModelDownloader()
-        models = downloader.list_models()
+        models = downloader.list_models(
+            format_filter=format_filter, location_filter=location_filter
+        )
 
         if json_output:
             import json
@@ -270,7 +279,10 @@ def remove_model(
         # Remove models
         downloader = ModelDownloader()
         success = downloader.remove_model(
-            model_name, format_type, location, delete_files
+            model_name,
+            format_type=format_type,
+            location=location,
+            delete_files=delete_files,
         )
 
         if success:

--- a/src/imageworks/tools/model_downloader/config.py
+++ b/src/imageworks/tools/model_downloader/config.py
@@ -149,13 +149,17 @@ class DownloaderConfig:
         self, format_type: str, model_name: str, publisher: Optional[str] = None
     ) -> Path:
         """Determine target directory for a model based on format."""
+        model_dir = model_name
+        if publisher and "/" not in model_dir:
+            model_dir = f"{publisher}/{model_dir}"
+
         if format_type == "gguf":
             if self.windows_lmstudio.publisher_structure and publisher:
                 return self.windows_lmstudio.root / publisher / model_name
             else:
-                return self.windows_lmstudio.root / model_name
+                return self.windows_lmstudio.root / model_dir
         else:
-            return self.linux_wsl.root / "weights" / model_name
+            return self.linux_wsl.root / "weights" / model_dir
 
     def get_compatible_backends(self, format_type: str) -> List[str]:
         """Get compatible backends for a given format."""


### PR DESCRIPTION
## Summary
- update the model downloader documentation to reflect current routing, format detection, CLI options, and Python API behaviour
- fix downloader CLI handling for format preference, location overrides, filtering, and removals to match the documented flows
- refresh the personal tagger architecture overview to cover the available prompt profiles and runtime orchestration details

## Testing
- uv run pytest tests/model_downloader

------
https://chatgpt.com/codex/tasks/task_e_68dd311837148322b61a58f6eba667f4