### PR TITLE
Harden duplicate identity handling in registry and downloader

### DIFF
--- a/src/imageworks/chat_proxy/app.py
+++ b/src/imageworks/chat_proxy/app.py
@@ -94,6 +94,8 @@ async def list_models_api():
 
     for name in list_models():
         entry = get_entry(name)
+        if entry.deprecated:
+            continue
         if not include_testing and is_testing_entry(name, entry):
             continue
         # Hide non-installed variants for non-Ollama backends to avoid ghost entries


### PR DESCRIPTION
## Summary
- add a strict download identity guard in the registry and expose a lookup helper for rename detection
- update the download adapter to migrate or rename existing entries that share the same downloaded weights instead of appending duplicates
- hide deprecated entries from the chat proxy /v1/models response to keep clients in sync

## Testing
- pytest tests/test_downloader_template_promotion.py *(fails: ModuleNotFoundError: No module named 'imageworks')*

------
https://chatgpt.com/codex/tasks/task_e_68e2320de52083228a68af975d75570e