### PR TITLE
Document capability normalization behavior

### DIFF
--- a/docs/architecture/model-loader-overview.md
+++ b/docs/architecture/model-loader-overview.md
@@ -237,6 +237,9 @@ A: Re-verify → aggregate hash drift; if locked, violation raised; if unlocked,
 **Q: How do deprecated entries differ from removed ones?**
 A: Deprecated remain in JSON (auditable); removed entries are physically deleted from the registry list.
 
+**Q: Do I need to drop and re-import models to pick up new capability synonyms?**
+A: No. Capability normalization happens every time the registry is loaded or a caller invokes `require_capabilities`, so restarting the process is enough to pick up the expanded synonyms. The underlying JSON does not need to be rewritten unless you want the normalized map persisted on disk.
+
 ## 18. Programmatic Usage Examples
 ### Recording a Download
 ```python

--- a/scripts/start_lmdeploy_server.py
+++ b/scripts/start_lmdeploy_server.py
@@ -165,7 +165,9 @@ def build_command(args: argparse.Namespace) -> List[str]:
         command.extend(["--api-keys", args.api_keys])
 
     if args.extra:
-        command.extend(args.extra)
+        forwarded = [token for token in args.extra if token and token != "--"]
+        if forwarded:
+            command.extend(forwarded)
 
     return command
 

--- a/src/imageworks/model_loader/api.py
+++ b/src/imageworks/model_loader/api.py
@@ -12,6 +12,7 @@ from .service import select_model, CapabilityError
 from .hashing import verify_model, VersionLockViolation
 from .probe import run_vision_probe
 from .metrics import RollingMetrics  # placeholder for future aggregation
+from .models import normalize_capabilities
 
 app = FastAPI(title="Imageworks Deterministic Model Loader", version="0.1")
 
@@ -62,7 +63,7 @@ async def api_list_models():
             ModelSummary(
                 name=name,
                 backend=entry.backend,
-                capabilities=entry.capabilities,
+                capabilities=normalize_capabilities(entry.capabilities),
                 locked=entry.version_lock.locked,
                 vision_ok=(
                     entry.probes.vision.vision_ok if entry.probes.vision else None
@@ -84,7 +85,7 @@ async def api_select(req: SelectRequest):
         endpoint=desc.endpoint_url,
         backend=desc.backend,
         internal_model_id=desc.internal_model_id,
-        capabilities=desc.capabilities,
+        capabilities=normalize_capabilities(desc.capabilities),
     )
 
 

--- a/src/imageworks/model_loader/registry.py
+++ b/src/imageworks/model_loader/registry.py
@@ -51,6 +51,7 @@ from .models import (
     RegistryEntry,
     VersionLock,
     VisionProbe,
+    normalize_capabilities,
 )
 
 _REGISTRY_CACHE: Dict[str, RegistryEntry] | None = None
@@ -365,6 +366,8 @@ def _parse_entry(raw: dict) -> RegistryEntry:
     perf_cfg = raw.get("performance", {})
     probes_cfg = raw.get("probes", {})
 
+    raw_caps = raw.get("capabilities") if isinstance(raw.get("capabilities"), dict) else {}
+
     entry = RegistryEntry(
         name=str(raw["name"]).strip(),
         display_name=str(raw.get("display_name") or raw.get("name") or "").strip()
@@ -375,7 +378,7 @@ def _parse_entry(raw: dict) -> RegistryEntry:
             model_path=str(backend_cfg.get("model_path", "")),
             extra_args=list(backend_cfg.get("extra_args", []) or []),
         ),
-        capabilities=dict(raw.get("capabilities", {})),
+        capabilities=normalize_capabilities(raw_caps),
         artifacts=Artifacts(
             aggregate_sha256=str(artifacts_cfg.get("aggregate_sha256", "")),
             files=[

--- a/src/imageworks/model_loader/service.py
+++ b/src/imageworks/model_loader/service.py
@@ -6,7 +6,7 @@ import logging
 from typing import List, Optional
 
 from .registry import get_entry, load_registry
-from .models import SelectedModel
+from .models import SelectedModel, normalize_capabilities
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +23,12 @@ def select_model(
     Minimal Phase 1: no process launching yet; returns derived endpoint from port.
     """
     entry = get_entry(name)
+    capabilities = normalize_capabilities(entry.capabilities)
+
     if require_capabilities:
-        missing = [c for c in require_capabilities if not entry.capabilities.get(c)]
+        missing = [
+            cap for cap in require_capabilities if not capabilities.get(cap.strip().lower(), False)
+        ]
         if missing:
             raise CapabilityError(
                 f"Model '{name}' is missing required capabilities: {', '.join(missing)}"
@@ -53,7 +57,7 @@ def select_model(
         endpoint_url=endpoint,
         internal_model_id=internal_id,
         backend=entry.backend,
-        capabilities=entry.capabilities,
+        capabilities=capabilities,
     )
 
 

--- a/tests/scripts/test_start_lmdeploy_server.py
+++ b/tests/scripts/test_start_lmdeploy_server.py
@@ -67,3 +67,26 @@ def test_validate_model_directory_warns_on_optional_assets(tmp_path):
 
     warnings = module.validate_model_directory(model_dir)
     assert any("chat_template.json" in warning for warning in warnings)
+
+
+def test_build_command_strips_remainder_sentinel():
+    module = load_module()
+    ns = types.SimpleNamespace(
+        model_path="/models/demo",
+        host="0.0.0.0",
+        port=9000,
+        model_name="demo",
+        backend="pytorch",
+        device="cuda",
+        vision_max_batch_size=1,
+        max_batch_size=None,
+        eager=True,
+        disable_fastapi_docs=False,
+        api_keys=None,
+        extra=["--", "--enable-auto-tool-choice", "--tool-call-parser", "openai"],
+    )
+
+    command = module.build_command(ns)
+    assert "--" not in command
+    assert "--enable-auto-tool-choice" in command
+    assert "--tool-call-parser" in command

--- a/tests/scripts/test_start_vllm_server.py
+++ b/tests/scripts/test_start_vllm_server.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from importlib import util
+from pathlib import Path
+import types
+
+
+def load_module() -> types.ModuleType:
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "start_vllm_server.py"
+    spec = util.spec_from_file_location("start_vllm_server", module_path)
+    module = util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+def test_build_command_strips_remainder_sentinel(tmp_path):
+    module = load_module()
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+
+    ns = types.SimpleNamespace(
+        model=str(model_path),
+        host="0.0.0.0",
+        port=8000,
+        served_model_name="demo",
+        tensor_parallel_size=1,
+        gpu_memory_utilization=0.85,
+        max_model_len=4096,
+        dtype="auto",
+        max_num_seqs=None,
+        max_num_batched_tokens=None,
+        kv_cache_dtype=None,
+        swap_space=None,
+        enforce_eager=False,
+        trust_remote_code=False,
+        api_keys=None,
+        chat_template=None,
+        extra=["--", "--enable-auto-tool-choice", "--tool-call-parser", "openai"],
+        background=False,
+        log_file=None,
+    )
+
+    command = module.build_command(ns)
+    assert "--" not in command
+    assert "--enable-auto-tool-choice" in command
+    assert "--tool-call-parser" in command
+    assert "openai" in command
+    assert "--chat-template-content-format" in command
+    assert command.index("--chat-template-content-format") < command.index(
+        "--tool-call-parser"
+    )
+
+
+def test_build_command_preserves_explicit_chat_format(tmp_path):
+    module = load_module()
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+
+    ns = types.SimpleNamespace(
+        model=str(model_path),
+        host="0.0.0.0",
+        port=8000,
+        served_model_name="demo",
+        tensor_parallel_size=1,
+        gpu_memory_utilization=0.85,
+        max_model_len=4096,
+        dtype="auto",
+        max_num_seqs=None,
+        max_num_batched_tokens=None,
+        kv_cache_dtype=None,
+        swap_space=None,
+        enforce_eager=False,
+        trust_remote_code=False,
+        api_keys=None,
+        chat_template=None,
+        extra=[
+            "--tool-call-parser",
+            "openai",
+            "--chat-template-content-format",
+            "string",
+        ],
+        background=False,
+        log_file=None,
+    )
+
+    command = module.build_command(ns)
+    assert command.count("--chat-template-content-format") == 1
+    assert command[command.index("--chat-template-content-format") + 1] == "string"
+
+
+def test_build_command_handles_equals_style(tmp_path):
+    module = load_module()
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+
+    ns = types.SimpleNamespace(
+        model=str(model_path),
+        host="0.0.0.0",
+        port=8000,
+        served_model_name="demo",
+        tensor_parallel_size=1,
+        gpu_memory_utilization=0.85,
+        max_model_len=4096,
+        dtype="auto",
+        max_num_seqs=None,
+        max_num_batched_tokens=None,
+        kv_cache_dtype=None,
+        swap_space=None,
+        enforce_eager=False,
+        trust_remote_code=False,
+        api_keys=None,
+        chat_template=None,
+        extra=["--tool-call-parser=openai"],
+        background=False,
+        log_file=None,
+    )
+
+    command = module.build_command(ns)
+    assert "--chat-template-content-format" in command
+    assert command[command.index("--chat-template-content-format") + 1] == "openai"


### PR DESCRIPTION
## Summary
- normalize registry capabilities, add synonym handling for tools/vision/reasoning, and expose normalized data via the service, CLI, and API
- tighten capability inference for downloads to better detect tool and reasoning support without false vision positives
- strip argparse remainder sentinels for vLLM/LMDeploy helpers and add regression tests for the launch scripts
- document the registry FAQ so operators know capability synonyms apply on the next process restart without purging entries
- inject `--chat-template-content-format openai` when the vLLM helper forwards the OpenAI tool parser flag and cover explicit/equals overrides in tests

## Testing
- pytest tests/scripts/test_start_vllm_server.py

------
https://chatgpt.com/codex/tasks/task_e_68e59915ea88832284d5725f7943bca7