### PR TITLE
Improve Ollama dry-run handling and registry compatibility

### DIFF
--- a/src/imageworks/chat_proxy/app.py
+++ b/src/imageworks/chat_proxy/app.py
@@ -94,7 +94,7 @@ async def list_models_api():
 
     for name in list_models():
         entry = get_entry(name)
-        if entry.deprecated:
+        if getattr(entry, "deprecated", False):
             continue
         if not include_testing and is_testing_entry(name, entry):
             continue


### PR DESCRIPTION
## Summary
- guard chat proxy model listing against registry entries that omit the deprecated flag
- allow the Ollama import script to fall back to a sample dataset during dry runs when the CLI is unavailable
- add a sample payload for dry runs so normalization logging still exercises slash-heavy identifiers

## Testing
- uv run ruff check scripts/import_ollama_models.py src/imageworks/chat_proxy/app.py
- uv run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5a2180c44832293febe438b3001a9