### PR TITLE
Add image similarity checker module

### DIFF
--- a/docs/analysis/image-similarity-grounding.md
+++ b/docs/analysis/image-similarity-grounding.md
@@ -1,0 +1,67 @@
+# Grounding Duplicate Detection Decisions
+
+The similarity checker is deliberately hybrid: deterministic perceptual hashes provide
+fast, reproducible flags for obvious duplicates, while learned embeddings capture tonal,
+crop, and minor edit variants. This combination keeps the system explainable and tunable.
+
+## Why Perceptual Hashes?
+
+Perceptual hashes (pHash/dHash) reduce an image to a binary signature resilient to minor
+changes such as scale, rotation, and exposure tweaks. They are:
+
+- **Fast** – simple downsampling and comparisons require no GPU.
+- **Deterministic** – identical inputs yield identical hashes, which helps during appeals.
+- **Grounded** – high similarity scores map directly to Hamming distance, enabling rule-based
+  explanations without AI involvement.
+
+However, hashes struggle with more aggressive edits (heavy colour grading, textures) or
+recomposed images. They form the "hard evidence" baseline and guard against drift.
+
+## Why Embeddings?
+
+Embedding models capture semantic and stylistic information beyond raw pixels. Using a
+configurable backend (`simple`, `open_clip`, `remote`) lets teams trade accuracy for
+performance or integrate with a model registry. Cosine similarity across normalised vectors
+works well for near-duplicate frames, alternate crops, and B&W conversions.
+
+Embedding outputs are averaged with deterministic evidence by picking the maximum score per
+candidate reference. This avoids double-counting while still surfacing the most convincing
+match across strategies.
+
+## Adjustable Verdict Bands
+
+Humans ultimately decide the boundary between "too similar" and "acceptably different". The
+checker exposes two thresholds:
+
+- **Fail threshold** – values above this are treated as automatic fails. Start high (0.9+) to
+  catch exact or near-exact duplicates and lower gradually if missed duplicates appear.
+- **Query threshold** – the caution band. Scores between `query_threshold` and `fail_threshold`
+  are flagged for manual review, keeping false positives manageable.
+
+During rollout, collect a set of known duplicates and borderline cases. Plot the scores and
+adjust thresholds until the pass/fail split matches curator expectations. Because strategies
+return normalised scores in `[0, 1]`, thresholds remain intuitive.
+
+## Alternative Signals Considered
+
+- **Classical feature matching (SIFT/SURF)** – accurate but slower at scale and patent-laden.
+- **Learned perceptual image patch similarity (LPIPS)** – powerful but requires GPU inference
+  and is less interpretable.
+- **FAISS vector databases** – ideal for very large archives, but adds operational overhead.
+  The current cache-based approach keeps complexity low. FAISS integration can be layered on
+  if latency becomes an issue.
+
+The chosen design prioritises reliability and incremental deployment. Strategies are modular:
+add a new implementation (e.g., SigLIP embeddings, LPIPS) and list it in `default_strategies`
+without rewriting orchestration code.
+
+## Tuning Guidance
+
+1. **Start with deterministic-only runs** (`--strategy perceptual_hash`) to establish baseline
+   behaviour and confirm metadata/report pipelines.
+2. **Introduce embeddings** with conservative fail thresholds and review cases above 0.85.
+3. **Log borderline scores** and gather curator feedback. Adjust thresholds accordingly.
+4. **Enable explanations** once thresholds stabilise. Prompt profiles reside in
+   `core/prompts.py` and can be versioned when the communication style evolves.
+
+Document agreed thresholds in the repository so future competitions understand the rationale.

--- a/docs/guides/image-similarity-checker.md
+++ b/docs/guides/image-similarity-checker.md
@@ -1,0 +1,78 @@
+# Image Similarity Checker
+
+The image similarity checker flags competition entries that match or closely resemble
+prior submissions. It combines deterministic perceptual hashes with configurable
+embedding models, produces JSONL/Markdown reports, and can annotate image metadata
+for downstream workflows.
+
+## Key Concepts
+
+- **Strategies** – Pluggable similarity algorithms. The default stack combines a
+  simple embedding descriptor with a perceptual hash for fast duplicate detection.
+  Strategies are configured via the `default_strategies` setting.
+- **Thresholds** – Scores above `fail_threshold` trigger a fail verdict, while scores
+  between `query_threshold` and `fail_threshold` yield a query for manual review.
+- **Prompt Profiles** – When explanations are enabled, the checker uses templated
+  prompts (stored in code) to request rationales from an OpenAI-compatible backend.
+- **Outputs** – Every run can emit JSONL (`outputs/results/similarity_results.jsonl`) and
+  Markdown (`outputs/summaries/similarity_summary.md`) summaries. Metadata updates are
+  optional and require ExifTool.
+
+## CLI Usage
+
+```bash
+uv run imageworks-image-similarity check \
+  /path/to/candidate/folder \
+  --library-root "/mnt/d/Proper Photos/photos/ccc competition images" \
+  --strategy perceptual_hash --strategy embedding \
+  --fail-threshold 0.92 --query-threshold 0.82 \
+  --output-jsonl outputs/results/similarity.jsonl \
+  --summary outputs/summaries/similarity_summary.md
+```
+
+### Common Flags
+
+| Option | Purpose |
+| --- | --- |
+| `--strategy` | Enable specific similarity strategies (`embedding`, `perceptual_hash`). |
+| `--embedding-backend` | Choose the embedding implementation (`simple`, `open_clip`, `remote`). |
+| `--library-root` | Override the default archive location. |
+| `--fail-threshold`, `--query-threshold` | Adjust sensitivity bands for fail/query verdicts. |
+| `--explain/--no-explain` | Toggle natural-language rationales using prompt profiles. |
+| `--write-metadata` | Append keywords with similarity verdicts to image files via ExifTool. |
+
+## Reports
+
+The JSONL file records one object per candidate image with raw scores and metadata. The
+Markdown report summarises verdicts in a table, then expands each candidate with notes,
+score breakdowns, and optional explanations. These artefacts align with the existing
+ImageWorks mono checker and personal tagger outputs.
+
+## Integration Tips
+
+1. **Pipeline Ordering** – Run the similarity checker immediately after ingesting entries.
+   Its JSONL output includes a `verdict` field that upstream automation can inspect before
+   running heavier modules (mono checker, colour narrator, personal tagger).
+2. **Caching** – Embedding strategies cache library vectors in `outputs/cache/similarity`.
+   Delete this cache to force regeneration after large library updates.
+3. **Metadata Writing** – Ensure ExifTool is installed when enabling metadata annotations.
+   Keywords follow the `similarity:*` namespace for easy filtering in Lightroom.
+4. **Explanations** – Configure an OpenAI-compatible endpoint in `pyproject.toml` when
+   enabling `--explain`. Prompt profiles live in code and can be versioned to tune tone.
+
+## Adjusting Thresholds
+
+The default thresholds (`0.92` fail, `0.82` query) were chosen to bias toward catching
+obvious duplicates. After reviewing real-world runs, update the `default_fail_threshold`
+and `default_query_threshold` values in `pyproject.toml`. Lower thresholds increase
+sensitivity (more queries/fails), while higher values reduce false positives.
+
+## Troubleshooting
+
+- **Missing embeddings** – Use `--strategy perceptual_hash` while debugging embedding
+  backends. The checker logs cache builds and errors per strategy.
+- **Long runtimes** – Build an embedding cache once, then keep `outputs/cache/similarity`
+  alongside the library. For large archives consider distributing strategy execution by
+  splitting the candidate list.
+- **Explanation failures** – Errors from the VLM backend are logged; the run still
+  completes without explanations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ quickly locate design references, domain guides, and operational procedures.
 ## How-To Guides
 - [AI Models and Prompting](guides/ai-models-and-prompting.md)
 - [IDE Setup (WSL/VSCode)](guides/ide-setup-wsl-vscode.md)
+- [Image Similarity Checker](guides/image-similarity-checker.md)
 
 ## Runbooks & Operational Playbooks
 - [Model Naming & Ollama Lingering Analysis](runbooks/model-naming-and-ollama-lingering.md)
@@ -36,6 +37,7 @@ quickly locate design references, domain guides, and operational procedures.
 
 ## Reference Material
 - [Model Downloader Guide](reference/model-downloader.md)
+- [Grounding Duplicate Detection Decisions](analysis/image-similarity-grounding.md)
 
 ## Specifications & Proposals
 - [Imageworks Specification](spec/imageworks-specification.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ imageworks-api = "imageworks.apps.mono_checker.api.main:start"
 imageworks-zip = "imageworks.tools.zip_extract:app"
 imageworks-color-narrator = "imageworks.apps.color_narrator.cli.main:app"
 imageworks-personal-tagger = "imageworks.apps.personal_tagger.cli.main:app"
+imageworks-image-similarity = "imageworks.apps.image_similarity_checker.cli.main:app"
 imageworks-download = "imageworks.tools.model_downloader.cli:main"
 imageworks-models = "imageworks.model_loader.cli:app"
 imageworks-models-api = "imageworks.model_loader.api:app"
@@ -219,6 +220,32 @@ image_extensions = [
   ".cr3",
 ]
 json_schema_version = "1.0"
+
+
+[tool.imageworks.image_similarity_checker]
+default_library_root = "/mnt/d/Proper Photos/photos/ccc competition images"
+default_output_jsonl = "outputs/results/similarity_results.jsonl"
+default_summary_path = "outputs/summaries/similarity_summary.md"
+default_cache_dir = "outputs/cache/similarity"
+default_strategies = ["embedding", "perceptual_hash"]
+default_fail_threshold = 0.92
+default_query_threshold = 0.82
+default_top_matches = 5
+default_similarity_metric = "cosine"
+default_embedding_backend = "simple"
+default_write_metadata = false
+default_backup_originals = true
+default_overwrite_metadata = false
+default_use_loader = false
+default_generate_explanations = false
+default_prompt_profile = "baseline"
+image_extensions = [
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".tif",
+  ".tiff",
+]
 
 
 [tool.imageworks.model-downloader]

--- a/src/imageworks/apps/image_similarity_checker/__init__.py
+++ b/src/imageworks/apps/image_similarity_checker/__init__.py
@@ -1,0 +1,5 @@
+"""Image similarity checker application package."""
+
+__all__ = [
+    "core",
+]

--- a/src/imageworks/apps/image_similarity_checker/cli/main.py
+++ b/src/imageworks/apps/image_similarity_checker/cli/main.py
@@ -1,0 +1,185 @@
+"""Command line interface for the image similarity checker module."""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+
+from imageworks.logging_utils import configure_logging
+
+from ..core.config import load_config
+from ..core.engine import SimilarityEngine
+from ..core.models import SimilarityVerdict
+from ..core.reporting import write_jsonl, write_markdown
+
+LOG_PATH = configure_logging("image_similarity_checker")
+logger = logging.getLogger(__name__)
+logger.info("Image similarity checker logging initialised → %s", LOG_PATH)
+
+app = typer.Typer(help="Identify duplicate and near-duplicate competition images.")
+
+
+@app.command()
+def check(
+    candidates: List[Path] = typer.Argument(
+        ..., metavar="CANDIDATE...", help="Candidate image files or directories."
+    ),
+    library_root: Optional[Path] = typer.Option(
+        None, "--library-root", "-L", help="Root directory containing historical submissions."
+    ),
+    output_jsonl: Optional[Path] = typer.Option(
+        None, "--output-jsonl", help="Machine-readable JSONL output path."
+    ),
+    summary_path: Optional[Path] = typer.Option(
+        None, "--summary", help="Human-readable Markdown summary path."
+    ),
+    fail_threshold: Optional[float] = typer.Option(
+        None,
+        "--fail-threshold",
+        help="Similarity score ≥ this value is marked as FAIL.",
+    ),
+    query_threshold: Optional[float] = typer.Option(
+        None,
+        "--query-threshold",
+        help="Similarity score ≥ this value triggers a QUERY.",
+    ),
+    top_matches: Optional[int] = typer.Option(
+        None, "--top-matches", help="Number of matches to retain per candidate."
+    ),
+    similarity_metric: Optional[str] = typer.Option(
+        None, "--metric", help="Similarity metric to use (cosine, euclidean, manhattan)."
+    ),
+    strategy: List[str] = typer.Option(
+        None,
+        "--strategy",
+        "-s",
+        help="Similarity strategy to enable (repeatable; e.g. embedding, perceptual_hash).",
+    ),
+    embedding_backend: Optional[str] = typer.Option(
+        None, "--embedding-backend", help="Embedding backend identifier (simple, open_clip, remote)."
+    ),
+    backend: Optional[str] = typer.Option(
+        None, "--backend", help="Inference backend name (lmdeploy, vllm, ollama, ...)."
+    ),
+    base_url: Optional[str] = typer.Option(
+        None, "--base-url", help="Base URL for OpenAI-compatible explanation/embedding endpoints."
+    ),
+    model: Optional[str] = typer.Option(
+        None, "--model", help="Model identifier for embeddings/explanations."
+    ),
+    api_key: Optional[str] = typer.Option(
+        None, "--api-key", help="API key for remote backends."
+    ),
+    timeout: Optional[int] = typer.Option(
+        None, "--timeout", help="Request timeout for remote backends (seconds)."
+    ),
+    prompt_profile: Optional[str] = typer.Option(
+        None, "--prompt-profile", help="Prompt profile for explanation generation."
+    ),
+    write_metadata: Optional[bool] = typer.Option(
+        None, "--write-metadata/--no-write-metadata", help="Write similarity verdicts to image metadata."
+    ),
+    backup_originals: Optional[bool] = typer.Option(
+        None, "--backup-originals/--no-backup-originals", help="Create backups before metadata writes."
+    ),
+    overwrite_metadata: Optional[bool] = typer.Option(
+        None, "--overwrite-metadata/--no-overwrite-metadata", help="Overwrite existing metadata keywords."
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run/--no-dry-run", help="Skip similarity computation and emit placeholder results."
+    ),
+    use_loader: Optional[bool] = typer.Option(
+        None, "--use-loader/--no-use-loader", help="Resolve models via the deterministic model loader."
+    ),
+    registry_model: Optional[str] = typer.Option(
+        None,
+        "--registry-model",
+        help="Logical model name from the model registry (requires --use-loader).",
+    ),
+    explain: Optional[bool] = typer.Option(
+        None,
+        "--explain/--no-explain",
+        help="Generate natural-language rationales using the configured backend.",
+    ),
+) -> None:
+    overrides: dict[str, object] = {
+        "library_root": library_root,
+        "output_jsonl": output_jsonl,
+        "summary_path": summary_path,
+        "fail_threshold": fail_threshold,
+        "query_threshold": query_threshold,
+        "top_matches": top_matches,
+        "similarity_metric": similarity_metric,
+        "embedding_backend": embedding_backend,
+        "backend": backend,
+        "base_url": base_url,
+        "model": model,
+        "api_key": api_key,
+        "timeout": timeout,
+        "prompt_profile": prompt_profile,
+        "write_metadata": write_metadata,
+        "backup_originals": backup_originals,
+        "overwrite_metadata": overwrite_metadata,
+        "dry_run": dry_run,
+        "use_loader": use_loader,
+        "registry_model": registry_model,
+        "generate_explanations": explain,
+    }
+    if strategy:
+        overrides["strategies"] = strategy
+
+    config = load_config(candidates=candidates, **{k: v for k, v in overrides.items() if v is not None})
+
+    logger.info(
+        "similarity_run_config",
+        extra={
+            "event_type": "config",
+            "candidates": [str(path) for path in config.candidates],
+            "library_root": str(config.library_root),
+            "strategies": list(config.strategies),
+            "metric": config.similarity_metric,
+            "fail_threshold": config.fail_threshold,
+            "query_threshold": config.query_threshold,
+            "embedding_backend": config.embedding_backend,
+            "generate_explanations": config.generate_explanations,
+        },
+    )
+
+    engine = SimilarityEngine(config)
+    try:
+        results = engine.run()
+    finally:
+        engine.close()
+
+    write_jsonl(results, config.output_jsonl)
+    write_markdown(results, config.summary_path)
+
+    _print_terminal_summary(results, config)
+
+
+def _print_terminal_summary(results, config) -> None:
+    verdict_counts = Counter(result.verdict for result in results)
+    typer.echo("\nSummary:")
+    for verdict in SimilarityVerdict:
+        typer.echo(
+            f"  {verdict.value.upper():>5}: {verdict_counts.get(verdict, 0)}"
+        )
+
+    typer.echo("\nTop matches:")
+    for result in results:
+        best = result.best_match()
+        best_name = best.reference.name if best else "—"
+        typer.echo(
+            f"  {result.candidate.name}: {result.verdict.value.upper()} (score={result.top_score:.3f}, match={best_name})"
+        )
+        if result.notes:
+            for note in result.notes:
+                typer.echo(f"    • {note}")
+
+    typer.echo(
+        f"\nDetailed JSONL → {config.output_jsonl}\nMarkdown summary → {config.summary_path}"
+    )

--- a/src/imageworks/apps/image_similarity_checker/core/config.py
+++ b/src/imageworks/apps/image_similarity_checker/core/config.py
@@ -1,0 +1,434 @@
+"""Configuration helpers for the image similarity checker module."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Sequence, Tuple
+
+import tomllib
+
+
+_CONFIG_ENV_PREFIX = "IMAGEWORKS_IMAGE_SIMILARITY__"
+
+
+def _find_pyproject(start: Optional[Path] = None) -> Optional[Path]:
+    """Locate the closest ``pyproject.toml`` relative to *start*."""
+
+    current = (start or Path.cwd()).resolve()
+    for candidate in [current, *current.parents]:
+        pyproject = candidate / "pyproject.toml"
+        if pyproject.exists():
+            return pyproject
+    return None
+
+
+def _coerce_bool(value: object, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _coerce_int(value: object, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except Exception:  # noqa: BLE001 - defensive coercion
+        return default
+
+
+def _coerce_float(value: object, default: float) -> float:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except Exception:  # noqa: BLE001 - defensive coercion
+        return default
+
+
+def _normalise_iterable(value: object) -> Tuple[str, ...]:
+    if value is None:
+        return tuple()
+    if isinstance(value, str):
+        parts = [part.strip() for part in value.split(",")]
+    elif isinstance(value, Iterable):
+        parts = []
+        for item in value:
+            if not item:
+                continue
+            parts.append(str(item).strip())
+    else:
+        return tuple()
+
+    return tuple(filter(None, parts))
+
+
+def _as_path(value: object) -> Optional[Path]:
+    if value is None:
+        return None
+    if isinstance(value, Path):
+        return value
+    if isinstance(value, str) and value.strip():
+        return Path(value).expanduser()
+    return None
+
+
+@dataclass(frozen=True)
+class SimilaritySettings:
+    """Default configuration values sourced from project metadata."""
+
+    default_candidates: Tuple[Path, ...] = field(default_factory=tuple)
+    default_library_root: Path = Path("/mnt/d/Proper Photos/photos/ccc competition images")
+    default_output_jsonl: Path = Path("outputs/results/similarity_results.jsonl")
+    default_summary_path: Path = Path("outputs/summaries/similarity_summary.md")
+    default_cache_dir: Path = Path("outputs/cache/similarity")
+    default_fail_threshold: float = 0.92
+    default_query_threshold: float = 0.82
+    default_top_matches: int = 5
+    default_similarity_metric: str = "cosine"
+    default_strategies: Tuple[str, ...] = ("embedding", "perceptual_hash")
+    default_recursive: bool = True
+    default_image_extensions: Tuple[str, ...] = (
+        ".jpg",
+        ".jpeg",
+        ".png",
+        ".tif",
+        ".tiff",
+    )
+    default_backend: str = "lmdeploy"
+    default_model: str = "Qwen2.5-VL-7B-AWQ"
+    default_base_url: str = "http://localhost:24001/v1"
+    default_timeout: int = 120
+    default_api_key: str = "EMPTY"
+    default_prompt_profile: str = "baseline"
+    default_write_metadata: bool = False
+    default_backup_originals: bool = True
+    default_overwrite_metadata: bool = False
+    default_use_loader: bool = False
+    default_registry_model: Optional[str] = None
+    default_embedding_backend: str = "simple"
+    default_generate_explanations: bool = False
+
+
+@dataclass(frozen=True)
+class SimilarityConfig:
+    """Fully resolved runtime configuration for a checker invocation."""
+
+    candidates: Tuple[Path, ...]
+    library_root: Path
+    output_jsonl: Path
+    summary_path: Path
+    cache_dir: Path
+    fail_threshold: float
+    query_threshold: float
+    top_matches: int
+    similarity_metric: str
+    strategies: Tuple[str, ...]
+    recursive: bool
+    image_extensions: Tuple[str, ...]
+    backend: str
+    embedding_backend: str
+    base_url: str
+    model: str
+    api_key: str
+    timeout: int
+    prompt_profile: str
+    write_metadata: bool
+    backup_originals: bool
+    overwrite_metadata: bool
+    dry_run: bool
+    use_loader: bool
+    registry_model: Optional[str]
+    generate_explanations: bool
+
+
+def _load_pyproject_settings(start: Optional[Path]) -> Dict[str, object]:
+    pyproject = _find_pyproject(start)
+    if not pyproject:
+        return {}
+
+    try:
+        with pyproject.open("rb") as handle:
+            data = tomllib.load(handle)
+    except Exception:  # noqa: BLE001 - fallback to defaults
+        return {}
+
+    tool_cfg = data.get("tool", {}).get("imageworks", {})
+    if not isinstance(tool_cfg, dict):
+        return {}
+
+    similarity_cfg = tool_cfg.get("image_similarity_checker")
+    return similarity_cfg if isinstance(similarity_cfg, dict) else {}
+
+
+def _load_env_settings() -> Dict[str, object]:
+    values: Dict[str, object] = {}
+    for env_key, env_value in os.environ.items():
+        if not env_key.startswith(_CONFIG_ENV_PREFIX):
+            continue
+        key = env_key[len(_CONFIG_ENV_PREFIX) :].lower()
+        values[key] = env_value
+    return values
+
+
+def load_settings(start: Optional[Path] = None) -> SimilaritySettings:
+    """Load project defaults, applying environment overrides when present."""
+
+    raw = _load_pyproject_settings(start)
+    raw.update(_load_env_settings())
+
+    candidate_paths: Tuple[Path, ...] = tuple()
+    default_candidate = _as_path(raw.get("default_candidate"))
+    if default_candidate is not None:
+        candidate_paths = (default_candidate.expanduser(),)
+
+    if not candidate_paths:
+        candidate_values = _normalise_iterable(raw.get("default_candidates"))
+        candidate_paths = tuple(Path(value).expanduser() for value in candidate_values)
+
+    library_root = _as_path(raw.get("default_library_root")) or SimilaritySettings.default_library_root
+    output_jsonl = _as_path(raw.get("default_output_jsonl")) or SimilaritySettings.default_output_jsonl
+    summary_path = _as_path(raw.get("default_summary_path")) or SimilaritySettings.default_summary_path
+    cache_dir = _as_path(raw.get("default_cache_dir")) or SimilaritySettings.default_cache_dir
+
+    fail_threshold = _coerce_float(
+        raw.get("default_fail_threshold"), SimilaritySettings.default_fail_threshold
+    )
+    query_threshold = _coerce_float(
+        raw.get("default_query_threshold"), SimilaritySettings.default_query_threshold
+    )
+    top_matches = _coerce_int(
+        raw.get("default_top_matches"), SimilaritySettings.default_top_matches
+    )
+    similarity_metric = str(
+        raw.get("default_similarity_metric"),
+    ).strip() or SimilaritySettings.default_similarity_metric
+
+    strategies = _normalise_iterable(raw.get("default_strategies")) or SimilaritySettings.default_strategies
+
+    recursive = _coerce_bool(
+        raw.get("default_recursive"), SimilaritySettings.default_recursive
+    )
+    image_extensions = _normalise_iterable(raw.get("image_extensions")) or SimilaritySettings.default_image_extensions
+
+    backend = str(raw.get("default_backend") or SimilaritySettings.default_backend).strip()
+    embedding_backend = str(
+        raw.get("default_embedding_backend")
+        or SimilaritySettings.default_embedding_backend
+    ).strip()
+    model = str(raw.get("default_model") or SimilaritySettings.default_model).strip()
+    base_url = str(raw.get("default_base_url") or SimilaritySettings.default_base_url).strip()
+    timeout = _coerce_int(raw.get("default_timeout"), SimilaritySettings.default_timeout)
+    api_key = str(raw.get("default_api_key") or SimilaritySettings.default_api_key)
+    prompt_profile = str(
+        raw.get("default_prompt_profile") or SimilaritySettings.default_prompt_profile
+    ).strip()
+    write_metadata = _coerce_bool(
+        raw.get("default_write_metadata"), SimilaritySettings.default_write_metadata
+    )
+    backup_originals = _coerce_bool(
+        raw.get("default_backup_originals"), SimilaritySettings.default_backup_originals
+    )
+    overwrite_metadata = _coerce_bool(
+        raw.get("default_overwrite_metadata"), SimilaritySettings.default_overwrite_metadata
+    )
+    use_loader = _coerce_bool(
+        raw.get("default_use_loader"), SimilaritySettings.default_use_loader
+    )
+    generate_explanations = _coerce_bool(
+        raw.get("default_generate_explanations"),
+        SimilaritySettings.default_generate_explanations,
+    )
+    registry_model = raw.get("default_registry_model")
+    if registry_model is not None:
+        registry_model = str(registry_model).strip() or None
+
+    return SimilaritySettings(
+        default_candidates=candidate_paths,
+        default_library_root=library_root,
+        default_output_jsonl=output_jsonl,
+        default_summary_path=summary_path,
+        default_cache_dir=cache_dir,
+        default_fail_threshold=fail_threshold,
+        default_query_threshold=query_threshold,
+        default_top_matches=top_matches,
+        default_similarity_metric=similarity_metric,
+        default_strategies=strategies,
+        default_recursive=recursive,
+        default_image_extensions=image_extensions,
+        default_backend=backend,
+        default_embedding_backend=embedding_backend,
+        default_model=model,
+        default_base_url=base_url,
+        default_timeout=timeout,
+        default_api_key=api_key,
+        default_prompt_profile=prompt_profile,
+        default_write_metadata=write_metadata,
+        default_backup_originals=backup_originals,
+        default_overwrite_metadata=overwrite_metadata,
+        default_use_loader=use_loader,
+        default_registry_model=registry_model,
+        default_generate_explanations=generate_explanations,
+    )
+
+
+def build_runtime_config(
+    *,
+    settings: SimilaritySettings,
+    candidates: Optional[Sequence[Path]] = None,
+    library_root: Optional[Path] = None,
+    output_jsonl: Optional[Path] = None,
+    summary_path: Optional[Path] = None,
+    cache_dir: Optional[Path] = None,
+    fail_threshold: Optional[float] = None,
+    query_threshold: Optional[float] = None,
+    top_matches: Optional[int] = None,
+    similarity_metric: Optional[str] = None,
+    strategies: Optional[Sequence[str]] = None,
+    recursive: Optional[bool] = None,
+    image_extensions: Optional[Sequence[str]] = None,
+    backend: Optional[str] = None,
+    embedding_backend: Optional[str] = None,
+    model: Optional[str] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    timeout: Optional[int] = None,
+    prompt_profile: Optional[str] = None,
+    write_metadata: Optional[bool] = None,
+    backup_originals: Optional[bool] = None,
+    overwrite_metadata: Optional[bool] = None,
+    dry_run: bool = False,
+    use_loader: Optional[bool] = None,
+    registry_model: Optional[str] = None,
+    generate_explanations: Optional[bool] = None,
+) -> SimilarityConfig:
+    """Merge CLI overrides with defaults to produce a runtime config."""
+
+    resolved_candidates = tuple(
+        path.expanduser() for path in (candidates or settings.default_candidates)
+    )
+    if not resolved_candidates:
+        raise ValueError("At least one candidate image or directory must be provided")
+
+    resolved_library = (library_root or settings.default_library_root).expanduser()
+    resolved_output = (output_jsonl or settings.default_output_jsonl).expanduser()
+    resolved_summary = (summary_path or settings.default_summary_path).expanduser()
+    resolved_cache = (cache_dir or settings.default_cache_dir).expanduser()
+
+    resolved_fail = (
+        settings.default_fail_threshold if fail_threshold is None else float(fail_threshold)
+    )
+    resolved_query = (
+        settings.default_query_threshold if query_threshold is None else float(query_threshold)
+    )
+    if not (0.0 <= resolved_query <= 1.0 and 0.0 <= resolved_fail <= 1.0):
+        raise ValueError("Thresholds must be in the range [0, 1]")
+    if resolved_fail < resolved_query:
+        raise ValueError("Fail threshold must be greater than or equal to query threshold")
+
+    resolved_top = int(top_matches or settings.default_top_matches)
+    resolved_metric = (
+        (similarity_metric or settings.default_similarity_metric).strip().lower()
+    )
+    resolved_strategies = tuple(
+        strategy.strip().lower()
+        for strategy in (strategies or settings.default_strategies)
+        if strategy and strategy.strip()
+    )
+    if not resolved_strategies:
+        raise ValueError("At least one similarity strategy must be configured")
+
+    resolved_recursive = (
+        settings.default_recursive if recursive is None else bool(recursive)
+    )
+    resolved_extensions = tuple(
+        ext if ext.startswith(".") else f".{ext}"
+        for ext in (image_extensions or settings.default_image_extensions)
+    )
+
+    resolved_backend = (backend or settings.default_backend).strip()
+    resolved_embedding_backend = (
+        embedding_backend or settings.default_embedding_backend
+    ).strip().lower()
+    resolved_model = (model or settings.default_model).strip()
+    resolved_base_url = (base_url or settings.default_base_url).strip()
+    resolved_api_key = (api_key or settings.default_api_key).strip()
+    resolved_timeout = int(timeout or settings.default_timeout)
+    resolved_prompt = (prompt_profile or settings.default_prompt_profile).strip()
+    resolved_write_meta = (
+        settings.default_write_metadata if write_metadata is None else bool(write_metadata)
+    )
+    resolved_backup_originals = (
+        settings.default_backup_originals
+        if backup_originals is None
+        else bool(backup_originals)
+    )
+    resolved_overwrite_metadata = (
+        settings.default_overwrite_metadata
+        if overwrite_metadata is None
+        else bool(overwrite_metadata)
+    )
+    resolved_generate_explanations = (
+        settings.default_generate_explanations
+        if generate_explanations is None
+        else bool(generate_explanations)
+    )
+    resolved_use_loader = (
+        settings.default_use_loader if use_loader is None else bool(use_loader)
+    )
+    resolved_registry = registry_model if registry_model is not None else settings.default_registry_model
+    if resolved_registry is not None:
+        resolved_registry = resolved_registry.strip() or None
+
+    return SimilarityConfig(
+        candidates=resolved_candidates,
+        library_root=resolved_library,
+        output_jsonl=resolved_output,
+        summary_path=resolved_summary,
+        cache_dir=resolved_cache,
+        fail_threshold=resolved_fail,
+        query_threshold=resolved_query,
+        top_matches=resolved_top,
+        similarity_metric=resolved_metric,
+        strategies=resolved_strategies,
+        recursive=resolved_recursive,
+        image_extensions=resolved_extensions,
+        backend=resolved_backend,
+        base_url=resolved_base_url,
+        model=resolved_model,
+        api_key=resolved_api_key,
+        timeout=resolved_timeout,
+        prompt_profile=resolved_prompt,
+        write_metadata=resolved_write_meta,
+        backup_originals=resolved_backup_originals,
+        overwrite_metadata=resolved_overwrite_metadata,
+        dry_run=dry_run,
+        use_loader=resolved_use_loader,
+        registry_model=resolved_registry,
+        embedding_backend=resolved_embedding_backend,
+        generate_explanations=resolved_generate_explanations,
+    )
+
+
+def load_config(
+    *,
+    start: Optional[Path] = None,
+    candidates: Optional[Sequence[Path]] = None,
+    **overrides: object,
+) -> SimilarityConfig:
+    """Convenience helper used by the CLI to resolve the runtime config."""
+
+    settings = load_settings(start)
+    return build_runtime_config(settings=settings, candidates=candidates, **overrides)

--- a/src/imageworks/apps/image_similarity_checker/core/discovery.py
+++ b/src/imageworks/apps/image_similarity_checker/core/discovery.py
@@ -1,0 +1,75 @@
+"""Filesystem helpers for locating candidate and library images."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def _normalise_extensions(extensions: Sequence[str]) -> Tuple[str, ...]:
+    result = []
+    for ext in extensions:
+        if not ext:
+            continue
+        clean = ext.lower()
+        result.append(clean if clean.startswith(".") else f".{clean}")
+    return tuple(dict.fromkeys(result))
+
+
+def _iter_directory(directory: Path, recursive: bool) -> Iterator[Path]:
+    if recursive:
+        yield from directory.rglob("*")
+    else:
+        yield from directory.iterdir()
+
+
+def discover_images(
+    paths: Sequence[Path],
+    *,
+    recursive: bool,
+    extensions: Sequence[str],
+) -> Tuple[Path, ...]:
+    """Return sorted unique image files under *paths*."""
+
+    allowed = _normalise_extensions(extensions)
+    seen: Set[Path] = set()
+    files: Set[Path] = set()
+
+    for root in paths:
+        if not root.exists():
+            logger.debug("Skipping missing input path: %s", root)
+            continue
+        if root.is_file():
+            if root.suffix.lower() in allowed:
+                files.add(root.resolve())
+            continue
+        if not root.is_dir():
+            logger.debug("Skipping non-file path: %s", root)
+            continue
+        for candidate in _iter_directory(root, recursive):
+            if not candidate.is_file():
+                continue
+            if candidate.suffix.lower() not in allowed:
+                continue
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            files.add(resolved)
+
+    return tuple(sorted(files))
+
+
+def discover_library(
+    library_root: Path,
+    *,
+    recursive: bool,
+    extensions: Sequence[str],
+    exclude: Iterable[Path] = (),
+) -> Tuple[Path, ...]:
+    exclude_set = {path.resolve() for path in exclude}
+    candidates = discover_images([library_root], recursive=recursive, extensions=extensions)
+    return tuple(path for path in candidates if path.resolve() not in exclude_set)

--- a/src/imageworks/apps/image_similarity_checker/core/embeddings.py
+++ b/src/imageworks/apps/image_similarity_checker/core/embeddings.py
@@ -1,0 +1,182 @@
+"""Embedding backends for the image similarity checker."""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Sequence
+
+import numpy as np
+from PIL import Image
+
+from .config import SimilarityConfig
+
+try:  # Optional dependency
+    import torch
+except Exception:  # pragma: no cover - dependency optional
+    torch = None  # type: ignore[assignment]
+
+try:  # Optional dependency
+    import open_clip
+except Exception:  # pragma: no cover - dependency optional
+    open_clip = None  # type: ignore[assignment]
+
+try:  # Optional dependency
+    import requests
+except Exception:  # pragma: no cover - dependency optional
+    requests = None  # type: ignore[assignment]
+
+
+class EmbeddingError(RuntimeError):
+    """Raised when an embedding backend cannot generate a vector."""
+
+
+class EmbeddingModel:
+    """Base class for feature extractors."""
+
+    def embed(self, image_path: Path) -> np.ndarray:
+        raise NotImplementedError
+
+    def batch_embed(self, image_paths: Sequence[Path]) -> Dict[Path, np.ndarray]:
+        return {path: self.embed(path) for path in image_paths}
+
+    @staticmethod
+    def _normalise(vector: np.ndarray) -> np.ndarray:
+        norm = float(np.linalg.norm(vector))
+        if norm == 0.0:
+            return vector
+        return vector / norm
+
+
+@dataclass
+class SimpleVisionEmbedding(EmbeddingModel):
+    """Deterministic visual descriptor using resized pixels + colour histograms."""
+
+    size: int = 48
+    histogram_bins: int = 24
+
+    def embed(self, image_path: Path) -> np.ndarray:  # noqa: D401 - see base
+        with Image.open(image_path) as image:
+            rgb = image.convert("RGB")
+            resized = rgb.resize((self.size, self.size), Image.Resampling.BILINEAR)
+            spatial = np.asarray(resized, dtype=np.float32) / 255.0
+            spatial_vector = spatial.flatten()
+
+            hist_components = []
+            for channel in range(3):
+                channel_data = spatial[:, :, channel]
+                hist, _ = np.histogram(
+                    channel_data, bins=self.histogram_bins, range=(0.0, 1.0), density=True
+                )
+                hist_components.append(hist.astype(np.float32))
+
+            feature = np.concatenate([spatial_vector, *hist_components]).astype(np.float32)
+            return self._normalise(feature)
+
+
+@dataclass
+class OpenClipEmbedding(EmbeddingModel):
+    """Wrapper around the open_clip vision encoder."""
+
+    model_name: str = "ViT-B-32"
+    pretrained: str = "openai"
+    device: str = "cpu"
+
+    def __post_init__(self) -> None:
+        if open_clip is None or torch is None:  # pragma: no cover - optional runtime
+            raise EmbeddingError(
+                "open_clip and torch must be installed to use the open_clip embedding backend"
+            )
+        self._model, _, self._preprocess = open_clip.create_model_and_transforms(  # type: ignore[union-attr]
+            self.model_name, pretrained=self.pretrained
+        )
+        self._model.to(self.device)
+        self._model.eval()
+
+    def embed(self, image_path: Path) -> np.ndarray:  # noqa: D401 - see base
+        if open_clip is None or torch is None:  # pragma: no cover - defensive
+            raise EmbeddingError("open_clip backend is unavailable")
+
+        with Image.open(image_path) as image:
+            rgb = image.convert("RGB")
+            tensor = self._preprocess(rgb).unsqueeze(0).to(self.device)
+
+        with torch.no_grad():  # type: ignore[union-attr]
+            features = self._model.encode_image(tensor)  # type: ignore[union-attr]
+            features = features / features.norm(dim=-1, keepdim=True)
+        return features.squeeze(0).cpu().numpy().astype(np.float32)
+
+
+@dataclass
+class RemoteEmbeddingClient(EmbeddingModel):
+    """Call an OpenAI-compatible endpoint to retrieve embeddings."""
+
+    base_url: str
+    model: str
+    api_key: str
+    timeout: int = 120
+
+    def __post_init__(self) -> None:
+        if requests is None:  # pragma: no cover - optional dependency
+            raise EmbeddingError("The 'requests' package is required for remote embeddings")
+        self._session = requests.Session()  # type: ignore[assignment]
+        self._endpoint = self.base_url.rstrip("/") + "/embeddings"
+
+    def embed(self, image_path: Path) -> np.ndarray:  # noqa: D401 - see base
+        if requests is None:  # pragma: no cover - defensive
+            raise EmbeddingError("Remote embeddings unavailable (requests missing)")
+
+        mime_type, _ = mimetypes.guess_type(image_path.name)
+        with image_path.open("rb") as handle:
+            payload = {
+                "model": self.model,
+                "input": [
+                    {
+                        "image": base64.b64encode(handle.read()).decode("utf-8"),
+                        "mime_type": mime_type or "image/jpeg",
+                    }
+                ],
+                "encoding_format": "float",
+            }
+
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        response = self._session.post(
+            self._endpoint,
+            json=payload,
+            headers=headers,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        vector = data.get("data", [{}])[0].get("embedding", [])
+        array = np.asarray(vector, dtype=np.float32)
+        if array.size == 0:
+            raise EmbeddingError("Remote embedding endpoint returned no data")
+        return self._normalise(array)
+
+    def batch_embed(self, image_paths: Sequence[Path]) -> Dict[Path, np.ndarray]:
+        # Remote batching can be expensive; fall back to default iterative behaviour.
+        return super().batch_embed(image_paths)
+
+
+def create_embedding_model(config: SimilarityConfig) -> EmbeddingModel:
+    """Factory for embedding backends based on configuration."""
+
+    backend = config.embedding_backend.lower()
+    if backend in {"simple", "baseline"}:
+        return SimpleVisionEmbedding()
+    if backend in {"open_clip", "clip"}:
+        return OpenClipEmbedding()
+    if backend in {"remote", "openai"}:
+        return RemoteEmbeddingClient(
+            base_url=config.base_url,
+            model=config.model,
+            api_key=config.api_key,
+            timeout=config.timeout,
+        )
+    raise EmbeddingError(f"Unknown embedding backend '{config.embedding_backend}'")

--- a/src/imageworks/apps/image_similarity_checker/core/engine.py
+++ b/src/imageworks/apps/image_similarity_checker/core/engine.py
@@ -1,0 +1,272 @@
+"""Core execution engine for the image similarity checker."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from imageworks.model_loader.service import CapabilityError, select_model
+
+from .config import SimilarityConfig
+from .discovery import discover_images, discover_library
+from .explainer import SimilarityExplainer, create_explainer
+from .metadata import SimilarityMetadataWriter
+from .models import CandidateSimilarity, SimilarityVerdict, StrategyMatch
+from .strategies import SimilarityStrategy, build_strategies
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EngineContext:
+    """Container for runtime data used by the engine."""
+
+    config: SimilarityConfig
+    candidate_images: Sequence[Path]
+    library_images: Sequence[Path]
+    strategies: Sequence[SimilarityStrategy]
+
+
+class SimilarityEngine:
+    """Coordinate discovery, strategy execution, and reporting."""
+
+    def __init__(
+        self,
+        config: SimilarityConfig,
+        *,
+        strategies: Optional[Sequence[SimilarityStrategy]] = None,
+        metadata_writer: Optional[SimilarityMetadataWriter] = None,
+    ) -> None:
+        self.config = self._resolve_model_via_loader(config)
+        self._strategies = list(strategies or build_strategies(self.config))
+        self._metadata_writer = metadata_writer
+        self._explainer: Optional[SimilarityExplainer] = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(self) -> List[CandidateSimilarity]:
+        """Execute similarity analysis for the configured candidates."""
+
+        candidate_images = discover_images(
+            list(self.config.candidates),
+            recursive=self.config.recursive,
+            extensions=self.config.image_extensions,
+        )
+        if not candidate_images:
+            raise ValueError("No candidate images were found for analysis")
+
+        if self.config.dry_run:
+            logger.info("Running similarity checker in dry-run mode")
+            return [
+                CandidateSimilarity(
+                    candidate=path,
+                    verdict=SimilarityVerdict.PASS,
+                    top_score=0.0,
+                    matches=[],
+                    thresholds={
+                        "fail": self.config.fail_threshold,
+                        "query": self.config.query_threshold,
+                    },
+                    metric=self.config.similarity_metric,
+                    notes=["Dry-run mode: similarity scores not computed"],
+                )
+                for path in candidate_images
+            ]
+
+        library_images = discover_library(
+            self.config.library_root,
+            recursive=self.config.recursive,
+            extensions=self.config.image_extensions,
+            exclude=candidate_images,
+        )
+        if not library_images:
+            logger.warning(
+                "No images discovered in library root %s", self.config.library_root
+            )
+
+        logger.info(
+            "similarity_engine_start",
+            extra={
+                "event_type": "similarity_start",
+                "candidates": len(candidate_images),
+                "library": len(library_images),
+                "strategies": [strategy.name for strategy in self._strategies],
+            },
+        )
+
+        context = EngineContext(
+            config=self.config,
+            candidate_images=candidate_images,
+            library_images=library_images,
+            strategies=self._strategies,
+        )
+
+        for strategy in context.strategies:
+            try:
+                strategy.prime(context.library_images)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Strategy %s failed during prime(): %s", strategy.name, exc)
+
+        results: List[CandidateSimilarity] = []
+        for candidate in context.candidate_images:
+            matches = self._evaluate_candidate(candidate, context.strategies)
+            aggregated = self._aggregate_matches(matches)
+            top_score = aggregated[0].score if aggregated else 0.0
+            verdict = self._classify(top_score)
+            result = CandidateSimilarity(
+                candidate=candidate,
+                verdict=verdict,
+                top_score=top_score,
+                matches=aggregated,
+                thresholds={
+                    "fail": self.config.fail_threshold,
+                    "query": self.config.query_threshold,
+                },
+                metric=self.config.similarity_metric,
+            )
+            if not aggregated:
+                result.notes.append("No comparable images found in library")
+            if verdict == SimilarityVerdict.QUERY:
+                result.notes.append(
+                    "Similarity score within query band; manual review recommended"
+                )
+            elif verdict == SimilarityVerdict.FAIL:
+                result.notes.append(
+                    "Similarity score exceeds fail threshold; duplicate likely"
+                )
+
+            results.append(result)
+
+            if self.config.write_metadata:
+                self._write_metadata(candidate, result)
+
+            if self.config.generate_explanations:
+                explanation = self._ensure_explainer().explain(result)
+                if explanation:
+                    result.notes.append(f"LLM rationale: {explanation}")
+
+        return results
+
+    def close(self) -> None:  # pragma: no cover - runtime cleanup
+        if self._explainer is not None:
+            self._explainer.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _evaluate_candidate(
+        self, candidate: Path, strategies: Sequence[SimilarityStrategy]
+    ) -> List[StrategyMatch]:
+        matches: List[StrategyMatch] = []
+        for strategy in strategies:
+            try:
+                matches.extend(strategy.find_matches(candidate, top_k=self.config.top_matches))
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Strategy %s failed for %s: %s", strategy.name, candidate, exc)
+        return matches
+
+    def _aggregate_matches(self, matches: Sequence[StrategyMatch]) -> List[StrategyMatch]:
+        if not matches:
+            return []
+
+        aggregated: dict[Path, dict[str, object]] = {}
+        for match in matches:
+            reference = match.reference.resolve()
+            entry = aggregated.setdefault(
+                reference,
+                {
+                    "reference": match.reference,
+                    "candidate": match.candidate,
+                    "score": 0.0,
+                    "strategies": {},
+                    "reasons": [],
+                    "details": {},
+                },
+            )
+            entry["score"] = max(float(entry["score"]), float(match.score))
+            entry["strategies"][match.strategy] = float(match.score)
+            if match.reason:
+                entry["reasons"].append(f"{match.strategy}: {match.reason}")
+            if match.extra:
+                entry["details"][match.strategy] = match.extra
+
+        aggregated_matches: List[StrategyMatch] = []
+        for info in aggregated.values():
+            reason = " | ".join(info["reasons"]) if info["reasons"] else "combined score"
+            aggregated_matches.append(
+                StrategyMatch(
+                    candidate=info["candidate"],
+                    reference=info["reference"],
+                    score=float(info["score"]),
+                    strategy="ensemble",
+                    reason=reason,
+                    extra={
+                        "strategies": info["strategies"],
+                        "details": info["details"],
+                    },
+                )
+            )
+
+        aggregated_matches.sort(key=lambda item: item.score, reverse=True)
+        return aggregated_matches[: self.config.top_matches]
+
+    def _classify(self, score: float) -> SimilarityVerdict:
+        if score >= self.config.fail_threshold:
+            return SimilarityVerdict.FAIL
+        if score >= self.config.query_threshold:
+            return SimilarityVerdict.QUERY
+        return SimilarityVerdict.PASS
+
+    def _write_metadata(self, candidate: Path, result: CandidateSimilarity) -> None:
+        writer = self._metadata_writer
+        if writer is None:
+            writer = SimilarityMetadataWriter(
+                backup_originals=self.config.backup_originals,
+                overwrite_existing=self.config.overwrite_metadata,
+            )
+            self._metadata_writer = writer
+        try:
+            wrote = writer.write(candidate, result)
+            logger.debug("Metadata %s for %s", "written" if wrote else "skipped", candidate)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to write metadata for %s: %s", candidate, exc)
+
+    def _ensure_explainer(self) -> SimilarityExplainer:
+        if self._explainer is None:
+            self._explainer = create_explainer(self.config)
+        return self._explainer
+
+    def _resolve_model_via_loader(self, config: SimilarityConfig) -> SimilarityConfig:
+        if not (config.use_loader or config.registry_model):
+            return config
+
+        logical_name = config.registry_model or config.model
+        try:
+            selected = select_model(logical_name, require_capabilities=["vision", "embedding"])
+        except CapabilityError as exc:  # pragma: no cover - integration path
+            raise RuntimeError(
+                f"Model '{logical_name}' is missing required capabilities: {exc}"
+            ) from exc
+        except Exception as exc:  # noqa: BLE001 - propagate context
+            raise RuntimeError(f"Failed to resolve model '{logical_name}': {exc}") from exc
+
+        logger.info(
+            "model_resolution",
+            extra={
+                "event_type": "model_resolution",
+                "logical": logical_name,
+                "endpoint": selected.endpoint_url,
+                "internal_model": selected.internal_model_id,
+                "backend": selected.backend,
+            },
+        )
+
+        return replace(
+            config,
+            backend=selected.backend,
+            base_url=selected.endpoint_url,
+            model=selected.internal_model_id,
+        )

--- a/src/imageworks/apps/image_similarity_checker/core/explainer.py
+++ b/src/imageworks/apps/image_similarity_checker/core/explainer.py
@@ -1,0 +1,94 @@
+"""Optional LLM explainer for similarity results."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from imageworks.libs.vlm import VLMBackend, VLMBackendError, create_backend_client
+
+from .config import SimilarityConfig
+from .models import CandidateSimilarity
+from .prompts import SimilarityPromptProfile, get_prompt_profile
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SimilarityExplainer:
+    """Generate natural-language rationales using an OpenAI-compatible backend."""
+
+    config: SimilarityConfig
+    prompt_profile: SimilarityPromptProfile
+
+    def __post_init__(self) -> None:
+        backend_name = self.config.backend.lower()
+        try:
+            self._backend = VLMBackend(backend_name)
+        except ValueError as exc:  # noqa: BLE001
+            raise RuntimeError(f"Unknown backend '{self.config.backend}' for explanations") from exc
+        self._client = create_backend_client(
+            self._backend,
+            base_url=self.config.base_url,
+            model_name=self.config.model,
+            api_key=self.config.api_key,
+            timeout=self.config.timeout,
+        )
+
+    def explain(self, result: CandidateSimilarity) -> Optional[str]:
+        if not result.matches:
+            return None
+        best = result.matches[0]
+        payload = self._build_payload(result)
+        try:
+            response = self._client.chat_completions(payload)
+        except VLMBackendError as exc:  # pragma: no cover - runtime only
+            logger.error("Explanation backend error: %s", exc)
+            return None
+        if response.status_code != 200:
+            logger.error("Explanation request failed: HTTP %s", response.status_code)
+            return None
+        data = response.json()
+        content = (
+            data.get("choices", [{}])[0]
+            .get("message", {})
+            .get("content", "")
+            .strip()
+        )
+        return content or None
+
+    def close(self) -> None:  # pragma: no cover - exercised in runtime
+        self._client.close()
+
+    def _build_payload(self, result: CandidateSimilarity) -> dict:
+        best = result.matches[0]
+        strategies = best.extra.get("strategies", {})
+        notes = "; ".join(result.notes) if result.notes else "(none)"
+        user_message = self.prompt_profile.render_user(
+            candidate=str(result.candidate),
+            best_match=str(best.reference),
+            score=result.top_score,
+            fail=self.config.fail_threshold,
+            query=self.config.query_threshold,
+            strategies=json.dumps(strategies, ensure_ascii=False, sort_keys=True),
+            verdict=result.verdict.value.upper(),
+            notes=notes,
+        )
+        messages = [
+            {"role": "system", "content": self.prompt_profile.system_prompt},
+            {"role": "user", "content": user_message},
+        ]
+        return {
+            "model": self.config.model,
+            "messages": messages,
+            "temperature": 0.2,
+            "top_p": 0.9,
+            "max_tokens": 256,
+        }
+
+
+def create_explainer(config: SimilarityConfig) -> SimilarityExplainer:
+    profile = get_prompt_profile(config.prompt_profile)
+    return SimilarityExplainer(config=config, prompt_profile=profile)

--- a/src/imageworks/apps/image_similarity_checker/core/metadata.py
+++ b/src/imageworks/apps/image_similarity_checker/core/metadata.py
@@ -1,0 +1,81 @@
+"""Metadata helper for persisting similarity verdicts."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List
+
+from .models import CandidateSimilarity
+
+logger = logging.getLogger(__name__)
+
+
+class SimilarityMetadataWriter:
+    """Write similarity outcomes to image metadata via ExifTool."""
+
+    def __init__(self, *, backup_originals: bool, overwrite_existing: bool) -> None:
+        self.backup_originals = backup_originals
+        self.overwrite_existing = overwrite_existing
+
+    def write(self, image_path: Path, result: CandidateSimilarity) -> bool:
+        if not shutil.which("exiftool"):
+            raise RuntimeError("ExifTool not found in PATH. Install exiftool to enable metadata writing.")
+
+        keywords = self._build_keywords(result)
+        if not keywords:
+            logger.debug("No similarity metadata to write for %s", image_path)
+            return False
+
+        command = ["exiftool"]
+        if not self.backup_originals or self.overwrite_existing:
+            command.append("-overwrite_original")
+
+        if self.overwrite_existing:
+            command.extend(["-XMP-dc:Subject=", "-IPTC:Keywords=", "-XMP-lr:HierarchicalSubject="])
+
+        for keyword in keywords:
+            command.extend(
+                [
+                    f"-XMP-dc:Subject+={keyword}",
+                    f"-IPTC:Keywords+={keyword}",
+                    f"-XMP-lr:HierarchicalSubject+={keyword}",
+                ]
+            )
+
+        command.append(str(image_path))
+
+        try:
+            subprocess.run(
+                command,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:  # pragma: no cover - fatal error
+            raise RuntimeError(
+                "ExifTool not found in PATH. Install exiftool to enable metadata writing."
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr.decode("utf-8", errors="ignore")
+            raise RuntimeError(stderr.strip() or "ExifTool metadata write failed") from exc
+
+        return True
+
+    @staticmethod
+    def _build_keywords(result: CandidateSimilarity) -> List[str]:
+        keywords = [
+            "imageworks:similarity",
+            f"similarity:verdict={result.verdict.value}",
+            f"similarity:score={result.top_score:.3f}",
+        ]
+        best_match = result.best_match()
+        if best_match is not None:
+            keywords.append(f"similarity:match={best_match.reference.name}")
+        strategies = best_match.extra.get("strategies") if best_match else {}
+        if isinstance(strategies, dict):
+            for name, score in strategies.items():
+                keywords.append(f"similarity:{name}={float(score):.3f}")
+        return keywords

--- a/src/imageworks/apps/image_similarity_checker/core/models.py
+++ b/src/imageworks/apps/image_similarity_checker/core/models.py
@@ -1,0 +1,65 @@
+"""Data models for image similarity analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+class SimilarityVerdict(str, Enum):
+    """Final status assigned to a candidate image."""
+
+    PASS = "pass"
+    QUERY = "query"
+    FAIL = "fail"
+
+
+@dataclass(frozen=True)
+class StrategyMatch:
+    """Similarity evidence returned by an individual strategy."""
+
+    candidate: Path
+    reference: Path
+    score: float
+    strategy: str
+    reason: str = ""
+    extra: Dict[str, object] = field(default_factory=dict)
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "candidate": str(self.candidate),
+            "reference": str(self.reference),
+            "score": float(self.score),
+            "strategy": self.strategy,
+            "reason": self.reason,
+            "extra": dict(self.extra),
+        }
+
+
+@dataclass
+class CandidateSimilarity:
+    """Aggregated similarity result for a candidate image."""
+
+    candidate: Path
+    verdict: SimilarityVerdict
+    top_score: float
+    matches: List[StrategyMatch] = field(default_factory=list)
+    thresholds: Dict[str, float] = field(default_factory=dict)
+    metric: str = "cosine"
+    notes: List[str] = field(default_factory=list)
+
+    def to_json(self) -> Dict[str, object]:
+        return {
+            "candidate": str(self.candidate),
+            "verdict": self.verdict.value,
+            "top_score": float(self.top_score),
+            "metric": self.metric,
+            "thresholds": dict(self.thresholds),
+            "matches": [match.as_dict() for match in self.matches],
+            "notes": list(self.notes),
+        }
+
+    def best_match(self) -> Optional[StrategyMatch]:
+        return self.matches[0] if self.matches else None

--- a/src/imageworks/apps/image_similarity_checker/core/prompts.py
+++ b/src/imageworks/apps/image_similarity_checker/core/prompts.py
@@ -1,0 +1,69 @@
+"""Prompt profiles for similarity explanations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from imageworks.libs.prompting import PromptLibrary, PromptProfileBase
+
+
+@dataclass(frozen=True)
+class SimilarityPromptProfile(PromptProfileBase):
+    """Prompt template for describing similarity verdicts."""
+
+    system_prompt: str
+    user_template: str
+
+    def render_user(self, **context: object) -> str:
+        return self.user_template.format(**context)
+
+
+PROFILES: Dict[int, SimilarityPromptProfile] = {
+    1: SimilarityPromptProfile(
+        id=1,
+        name="baseline",
+        description="Explain similarity verdicts using computed metrics and thresholds.",
+        system_prompt=(
+            "You are an expert photo competition judge."
+            " Explain to organisers whether two images appear to be duplicates,"
+            " considering quantitative similarity metrics and any reviewer notes."
+            " Keep the tone factual and concise."
+        ),
+        user_template=(
+            "Candidate image: {candidate}\n"
+            "Best library match: {best_match}\n"
+            "Similarity score: {score:.3f}\n"
+            "Fail threshold: {fail:.2f}\n"
+            "Query threshold: {query:.2f}\n"
+            "Strategy scores: {strategies}\n"
+            "Current verdict: {verdict}\n"
+            "Existing notes: {notes}\n"
+            "Provide a short justification (2-3 sentences) clarifying whether this should be PASS, QUERY, or FAIL."
+        ),
+    ),
+    2: SimilarityPromptProfile(
+        id=2,
+        name="conservative",
+        description="Emphasise caution by highlighting uncertainty and recommending manual review when appropriate.",
+        system_prompt=(
+            "You assist competition moderators by summarising similarity evidence."
+            " Focus on highlighting risks and suggesting manual review when data is borderline."
+        ),
+        user_template=(
+            "Candidate: {candidate}\n"
+            "Closest match: {best_match}\n"
+            "Similarity score: {score:.3f}\n"
+            "Fail threshold: {fail:.2f}, Query threshold: {query:.2f}\n"
+            "Strategy breakdown: {strategies}\n"
+            "Observed notes: {notes}\n"
+            "Explain the recommendation in 3 sentences, flagging any uncertainty."
+        ),
+    ),
+}
+
+PROMPT_LIBRARY = PromptLibrary(PROFILES, default_id=1)
+
+
+def get_prompt_profile(identifier=None) -> SimilarityPromptProfile:
+    return PROMPT_LIBRARY.get(identifier)

--- a/src/imageworks/apps/image_similarity_checker/core/reporting.py
+++ b/src/imageworks/apps/image_similarity_checker/core/reporting.py
@@ -1,0 +1,69 @@
+"""Report generation for the image similarity checker."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Sequence
+
+from .models import CandidateSimilarity
+
+
+def write_jsonl(results: Sequence[CandidateSimilarity], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for result in results:
+            handle.write(json.dumps(result.to_json(), ensure_ascii=False))
+            handle.write("\n")
+
+
+def write_markdown(results: Sequence[CandidateSimilarity], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = ["# Image Similarity Checker Report", ""]
+    if not results:
+        lines.append("No candidate images were processed.")
+    else:
+        lines.extend(
+            [
+                "| Candidate | Verdict | Top score | Best match | Strategies |",
+                "| --- | --- | --- | --- | --- |",
+            ]
+        )
+        for result in results:
+            best = result.best_match()
+            best_path = best.reference.name if best else "—"
+            strategies = ", ".join(sorted(best.extra.get("strategies", {}).keys())) if best else "—"
+            lines.append(
+                "| {candidate} | {verdict} | {score:.3f} | {best_match} | {strategies} |".format(
+                    candidate=result.candidate.name,
+                    verdict=result.verdict.value.upper(),
+                    score=result.top_score,
+                    best_match=best_path,
+                    strategies=strategies or "—",
+                )
+            )
+        lines.append("")
+
+        for result in results:
+            lines.append(f"## {result.candidate.name}")
+            lines.append("")
+            lines.append(f"- Verdict: **{result.verdict.value.upper()}**")
+            lines.append(f"- Top score: {result.top_score:.3f} ({result.metric})")
+            if result.matches:
+                lines.append("- Matches:")
+                for match in result.matches:
+                    strategies = match.extra.get("strategies", {})
+                    strategy_summary = ", ".join(
+                        f"{name}={score:.3f}" for name, score in strategies.items()
+                    )
+                    lines.append(
+                        f"  - {match.reference}: {match.score:.3f} [{strategy_summary or match.strategy}]"
+                    )
+            if result.notes:
+                lines.append("- Notes:")
+                for note in result.notes:
+                    lines.append(f"  - {note}")
+            lines.append("")
+
+    path.write_text("\n".join(lines), encoding="utf-8")

--- a/src/imageworks/apps/image_similarity_checker/core/strategies.py
+++ b/src/imageworks/apps/image_similarity_checker/core/strategies.py
@@ -1,0 +1,247 @@
+"""Similarity strategies combining deterministic and embedding approaches."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+import numpy as np
+from PIL import Image
+
+from .config import SimilarityConfig
+from .embeddings import EmbeddingModel, EmbeddingError, create_embedding_model
+from .models import StrategyMatch
+
+logger = logging.getLogger(__name__)
+
+
+class SimilarityStrategy:
+    """Base class for similarity scoring strategies."""
+
+    name: str
+
+    def prime(self, library_paths: Sequence[Path]) -> None:
+        """Prepare any state derived from the historical library."""
+
+    def find_matches(self, candidate: Path, *, top_k: int) -> List[StrategyMatch]:
+        """Return top *top_k* matches for the candidate image."""
+        raise NotImplementedError
+
+
+@dataclass
+class EmbeddingSimilarityStrategy(SimilarityStrategy):
+    """Similarity scoring based on image embeddings."""
+
+    config: SimilarityConfig
+    cache_path: Path
+    metric: str = "cosine"
+
+    def __post_init__(self) -> None:
+        self.name = "embedding"
+        self._embedding_model: EmbeddingModel | None = None
+        self._library_vectors: Dict[Path, np.ndarray] = {}
+        self.metric = self.metric.lower()
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Library preparation
+    # ------------------------------------------------------------------
+    def prime(self, library_paths: Sequence[Path]) -> None:  # noqa: D401 - see base
+        embedding_model = self._get_model()
+        cache = self._load_cache()
+
+        to_encode: List[Path] = []
+        for path in library_paths:
+            key = str(path)
+            try:
+                mtime = path.stat().st_mtime
+            except FileNotFoundError:
+                logger.debug("Skipping missing library image: %s", path)
+                continue
+
+            cached = cache.get(key)
+            if cached and cached.get("mtime") == mtime:
+                vector = np.asarray(cached["vector"], dtype=np.float32)
+                self._library_vectors[path] = EmbeddingModel._normalise(vector)
+            else:
+                to_encode.append(path)
+
+        if to_encode:
+            logger.info(
+                "embedding_index_build",
+                extra={
+                    "event_type": "embedding_index_build",
+                    "count": len(to_encode),
+                    "strategy": self.name,
+                },
+            )
+            try:
+                encoded = embedding_model.batch_embed(to_encode)
+            except Exception as exc:  # noqa: BLE001 - resilient runtime
+                logger.error("Embedding generation failed: %s", exc)
+                encoded = {}
+            for path, vector in encoded.items():
+                self._library_vectors[path] = EmbeddingModel._normalise(vector)
+                try:
+                    mtime = path.stat().st_mtime
+                except FileNotFoundError:
+                    continue
+                cache[str(path)] = {
+                    "vector": vector.astype(np.float32).tolist(),
+                    "mtime": mtime,
+                }
+            self._save_cache(cache)
+
+    # ------------------------------------------------------------------
+    # Matching
+    # ------------------------------------------------------------------
+    def find_matches(self, candidate: Path, *, top_k: int) -> List[StrategyMatch]:
+        embedding_model = self._get_model()
+        try:
+            vector = EmbeddingModel._normalise(embedding_model.embed(candidate))
+        except Exception as exc:  # noqa: BLE001 - ensure graceful degradation
+            logger.error("Failed to embed candidate %s: %s", candidate, exc)
+            return []
+
+        matches: List[StrategyMatch] = []
+        for reference, ref_vector in self._library_vectors.items():
+            score = self._compute_similarity(vector, ref_vector)
+            matches.append(
+                StrategyMatch(
+                    candidate=candidate,
+                    reference=reference,
+                    score=score,
+                    strategy=self.name,
+                    reason=f"cosine similarity {score:.3f}" if self.metric == "cosine" else "embedding comparison",
+                    extra={"metric": self.metric},
+                )
+            )
+
+        matches.sort(key=lambda item: item.score, reverse=True)
+        return matches[:top_k]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _get_model(self) -> EmbeddingModel:
+        if self._embedding_model is None:
+            try:
+                self._embedding_model = create_embedding_model(self.config)
+            except EmbeddingError as exc:
+                raise EmbeddingError(
+                    f"Failed to initialise embedding backend '{self.config.embedding_backend}': {exc}"
+                ) from exc
+        return self._embedding_model
+
+    def _compute_similarity(self, a: np.ndarray, b: np.ndarray) -> float:
+        if self.metric == "cosine":
+            return float(np.dot(a, b))
+        if self.metric == "dot":
+            return float(np.dot(a, b))
+        if self.metric == "euclidean":
+            distance = float(np.linalg.norm(a - b))
+            return float(1.0 / (1.0 + distance))
+        if self.metric == "manhattan":
+            distance = float(np.abs(a - b).sum())
+            return float(1.0 / (1.0 + distance))
+        raise ValueError(f"Unsupported similarity metric '{self.metric}'")
+
+    def _load_cache(self) -> Dict[str, Dict[str, object]]:
+        if not self.cache_path.exists():
+            return {}
+        try:
+            data = np.load(self.cache_path, allow_pickle=True)
+            cached = data.get("data")
+            if isinstance(cached, np.ndarray) and cached.size == 1:
+                stored = cached.item()
+                if isinstance(stored, dict):
+                    return stored
+        except Exception as exc:  # noqa: BLE001 - cache corruption fallback
+            logger.warning("Failed to load embedding cache %s: %s", self.cache_path, exc)
+        return {}
+
+    def _save_cache(self, cache: Dict[str, Dict[str, object]]) -> None:
+        try:
+            np.savez(self.cache_path, data=cache)
+        except Exception as exc:  # noqa: BLE001 - cache write failure
+            logger.warning("Failed to persist embedding cache %s: %s", self.cache_path, exc)
+
+
+@dataclass
+class PerceptualHashStrategy(SimilarityStrategy):
+    """Lightweight perceptual hash comparison using difference hash."""
+
+    hash_size: int = 32
+
+    def __post_init__(self) -> None:
+        self.name = "perceptual_hash"
+        self._library_hashes: Dict[Path, np.ndarray] = {}
+
+    def prime(self, library_paths: Sequence[Path]) -> None:  # noqa: D401 - see base
+        for path in library_paths:
+            try:
+                self._library_hashes[path] = self._hash(path)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Hashing failed for %s: %s", path, exc)
+
+    def find_matches(self, candidate: Path, *, top_k: int) -> List[StrategyMatch]:
+        candidate_hash = self._hash(candidate)
+        matches: List[StrategyMatch] = []
+
+        for reference, ref_hash in self._library_hashes.items():
+            similarity = self._hash_similarity(candidate_hash, ref_hash)
+            matches.append(
+                StrategyMatch(
+                    candidate=candidate,
+                    reference=reference,
+                    score=similarity,
+                    strategy=self.name,
+                    reason=f"perceptual hash similarity {similarity:.3f}",
+                    extra={"hash_size": self.hash_size},
+                )
+            )
+
+        matches.sort(key=lambda item: item.score, reverse=True)
+        return matches[:top_k]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _hash(self, image_path: Path) -> np.ndarray:
+        with Image.open(image_path) as image:
+            gray = image.convert("L")
+            resized = gray.resize((self.hash_size + 1, self.hash_size), Image.Resampling.LANCZOS)
+            data = np.asarray(resized, dtype=np.float32)
+            diff = data[:, 1:] > data[:, :-1]
+            return diff.flatten()
+
+    def _hash_similarity(self, a: np.ndarray, b: np.ndarray) -> float:
+        if a.shape != b.shape:
+            size = min(a.size, b.size)
+            a = a[:size]
+            b = b[:size]
+        hamming = float(np.count_nonzero(a != b))
+        return float(1.0 - (hamming / max(1.0, a.size)))
+
+
+def build_strategies(config: SimilarityConfig) -> List[SimilarityStrategy]:
+    """Factory for the configured set of strategies."""
+
+    strategies: List[SimilarityStrategy] = []
+    for name in config.strategies:
+        if name == "embedding":
+            cache_path = config.cache_dir / "embedding_index.npz"
+            strategies.append(
+                EmbeddingSimilarityStrategy(
+                    config=config,
+                    cache_path=cache_path,
+                    metric=config.similarity_metric,
+                )
+            )
+        elif name in {"phash", "perceptual_hash", "dhash"}:
+            strategies.append(PerceptualHashStrategy())
+        else:
+            raise ValueError(f"Unknown similarity strategy '{name}'")
+    return strategies

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/image_similarity/test_cli.py
+++ b/tests/image_similarity/test_cli.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+import pytest
+
+typer_testing = pytest.importorskip("typer.testing")
+pytest.importorskip("PIL")
+from PIL import Image
+
+from imageworks.apps.image_similarity_checker.cli.main import app
+
+CliRunner = typer_testing.CliRunner
+
+runner = CliRunner()
+
+
+def _make_image(path: Path, colour: tuple[int, int, int]) -> None:
+    Image.new("RGB", (32, 32), colour).save(path)
+
+
+def test_cli_runs_similarity(tmp_path: Path) -> None:
+    candidate_dir = tmp_path / "candidates"
+    library_dir = tmp_path / "library"
+    candidate_dir.mkdir()
+    library_dir.mkdir()
+
+    candidate = candidate_dir / "candidate.jpg"
+    duplicate = library_dir / "duplicate.jpg"
+    _make_image(candidate, (100, 120, 130))
+    _make_image(duplicate, (100, 120, 130))
+
+    jsonl_path = tmp_path / "results.jsonl"
+    md_path = tmp_path / "summary.md"
+
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(candidate),
+            "--library-root",
+            str(library_dir),
+            "--strategy",
+            "perceptual_hash",
+            "--output-jsonl",
+            str(jsonl_path),
+            "--summary",
+            str(md_path),
+            "--fail-threshold",
+            "0.9",
+            "--query-threshold",
+            "0.8",
+            "--no-write-metadata",
+            "--no-explain",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert jsonl_path.exists()
+    assert md_path.exists()
+    content = jsonl_path.read_text(encoding="utf-8")
+    assert "fail" in content.lower()

--- a/tests/image_similarity/test_config.py
+++ b/tests/image_similarity/test_config.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pytest
+
+from imageworks.apps.image_similarity_checker.core.config import (
+    SimilarityConfig,
+    SimilaritySettings,
+    build_runtime_config,
+)
+
+
+def test_build_runtime_config_validates_thresholds():
+    settings = SimilaritySettings(default_candidates=(Path("candidate.jpg"),))
+    with pytest.raises(ValueError):
+        build_runtime_config(
+            settings=settings,
+            candidates=[Path("candidate.jpg")],
+            library_root=Path("library"),
+            fail_threshold=0.5,
+            query_threshold=0.6,
+        )
+
+
+def test_build_runtime_config_overrides(tmp_path: Path):
+    candidate = tmp_path / "candidate.jpg"
+    candidate.touch()
+    library = tmp_path / "library"
+    library.mkdir()
+
+    settings = SimilaritySettings(
+        default_candidates=(candidate,),
+        default_library_root=library,
+        default_output_jsonl=tmp_path / "results.jsonl",
+        default_summary_path=tmp_path / "summary.md",
+        default_cache_dir=tmp_path / "cache",
+        default_strategies=("perceptual_hash",),
+        default_write_metadata=False,
+        default_generate_explanations=False,
+    )
+
+    config = build_runtime_config(
+        settings=settings,
+        candidates=[candidate],
+        library_root=library,
+        strategies=["perceptual_hash"],
+        fail_threshold=0.95,
+        query_threshold=0.85,
+        embedding_backend="simple",
+        generate_explanations=True,
+    )
+
+    assert isinstance(config, SimilarityConfig)
+    assert config.library_root == library
+    assert config.fail_threshold == pytest.approx(0.95)
+    assert config.query_threshold == pytest.approx(0.85)
+    assert config.strategies == ("perceptual_hash",)
+    assert config.embedding_backend == "simple"
+    assert config.generate_explanations is True

--- a/tests/image_similarity/test_engine.py
+++ b/tests/image_similarity/test_engine.py
@@ -1,0 +1,81 @@
+from dataclasses import replace
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PIL")
+from PIL import Image
+
+from imageworks.apps.image_similarity_checker.core.config import (
+    SimilaritySettings,
+    build_runtime_config,
+)
+from imageworks.apps.image_similarity_checker.core.engine import SimilarityEngine
+from imageworks.apps.image_similarity_checker.core.models import SimilarityVerdict
+
+
+def _make_image(path: Path, colour: tuple[int, int, int]) -> None:
+    Image.new("RGB", (32, 32), colour).save(path)
+
+
+def test_engine_perceptual_hash(tmp_path: Path) -> None:
+    candidate_dir = tmp_path / "candidates"
+    candidate_dir.mkdir()
+    library_dir = tmp_path / "library"
+    library_dir.mkdir()
+
+    candidate = candidate_dir / "candidate.jpg"
+    duplicate = library_dir / "duplicate.jpg"
+    different = library_dir / "different.jpg"
+
+    _make_image(candidate, (200, 50, 50))
+    _make_image(duplicate, (200, 50, 50))
+    _make_image(different, (20, 200, 200))
+
+    settings = SimilaritySettings(
+        default_candidates=(candidate,),
+        default_library_root=library_dir,
+        default_output_jsonl=tmp_path / "results.jsonl",
+        default_summary_path=tmp_path / "summary.md",
+        default_cache_dir=tmp_path / "cache",
+        default_strategies=("perceptual_hash",),
+        default_fail_threshold=0.9,
+        default_query_threshold=0.8,
+        default_write_metadata=False,
+        default_generate_explanations=False,
+    )
+
+    config = build_runtime_config(
+        settings=settings,
+        candidates=[candidate],
+        library_root=library_dir,
+        strategies=["perceptual_hash"],
+        fail_threshold=0.9,
+        query_threshold=0.8,
+        write_metadata=False,
+        generate_explanations=False,
+    )
+
+    engine = SimilarityEngine(config)
+    try:
+        results = engine.run()
+    finally:
+        engine.close()
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.verdict == SimilarityVerdict.FAIL
+    assert result.matches
+    assert result.matches[0].reference == duplicate
+
+    # Dry-run mode returns placeholder data
+    dry_config = replace(config, dry_run=True)
+    engine = SimilarityEngine(dry_config)
+    try:
+        dry_results = engine.run()
+    finally:
+        engine.close()
+
+    assert dry_results[0].verdict == SimilarityVerdict.PASS
+    assert not dry_results[0].matches

--- a/tests/image_similarity/test_metadata.py
+++ b/tests/image_similarity/test_metadata.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from imageworks.apps.image_similarity_checker.core.metadata import (
+    SimilarityMetadataWriter,
+)
+from imageworks.apps.image_similarity_checker.core.models import (
+    CandidateSimilarity,
+    SimilarityVerdict,
+    StrategyMatch,
+)
+
+
+def _result(tmp_path: Path) -> CandidateSimilarity:
+    candidate = tmp_path / "candidate.jpg"
+    reference = tmp_path / "match.jpg"
+    match = StrategyMatch(
+        candidate=candidate,
+        reference=reference,
+        score=0.92,
+        strategy="perceptual_hash",
+        extra={"strategies": {"perceptual_hash": 0.92}},
+    )
+    return CandidateSimilarity(
+        candidate=candidate,
+        verdict=SimilarityVerdict.QUERY,
+        top_score=0.92,
+        matches=[match],
+        thresholds={"fail": 0.95, "query": 0.85},
+        metric="cosine",
+        notes=["Similarity score within query band; manual review recommended"],
+    )
+
+
+def test_metadata_writer_keywords(tmp_path: Path, monkeypatch) -> None:
+    candidate = tmp_path / "candidate.jpg"
+    candidate.write_bytes(b"fake")
+    result = _result(tmp_path)
+
+    writer = SimilarityMetadataWriter(backup_originals=False, overwrite_existing=False)
+
+    commands: List[List[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda name: str(tmp_path / "exiftool"))
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001 - mimic subprocess.run signature
+        commands.append(cmd)
+        class Completed:
+            returncode = 0
+            stdout = b""
+            stderr = b""
+
+        return Completed()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    wrote = writer.write(candidate, result)
+    assert wrote is True
+    assert commands
+    # Ensure custom keywords are appended
+    joined = " ".join(commands[0])
+    assert "similarity:verdict=query" in joined
+    assert "similarity:perceptual_hash=0.920" in joined
+
+
+def test_metadata_writer_missing_exiftool(tmp_path: Path, monkeypatch) -> None:
+    candidate = tmp_path / "candidate.jpg"
+    candidate.write_bytes(b"fake")
+    result = _result(tmp_path)
+
+    writer = SimilarityMetadataWriter(backup_originals=False, overwrite_existing=False)
+
+    monkeypatch.setattr("shutil.which", lambda name: None)
+
+    with pytest.raises(RuntimeError):
+        writer.write(candidate, result)

--- a/tests/image_similarity/test_reporting.py
+++ b/tests/image_similarity/test_reporting.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+
+from imageworks.apps.image_similarity_checker.core.models import (
+    CandidateSimilarity,
+    SimilarityVerdict,
+    StrategyMatch,
+)
+from imageworks.apps.image_similarity_checker.core.reporting import (
+    write_jsonl,
+    write_markdown,
+)
+
+
+def _sample_result(tmp_path: Path) -> CandidateSimilarity:
+    candidate = tmp_path / "candidate.jpg"
+    reference = tmp_path / "match.jpg"
+    match = StrategyMatch(
+        candidate=candidate,
+        reference=reference,
+        score=0.95,
+        strategy="perceptual_hash",
+        reason="perceptual hash similarity 0.950",
+        extra={"strategies": {"perceptual_hash": 0.95}},
+    )
+    result = CandidateSimilarity(
+        candidate=candidate,
+        verdict=SimilarityVerdict.FAIL,
+        top_score=0.95,
+        matches=[match],
+        thresholds={"fail": 0.9, "query": 0.8},
+        metric="cosine",
+        notes=["Similarity score exceeds fail threshold; duplicate likely"],
+    )
+    return result
+
+
+def test_write_jsonl_and_markdown(tmp_path: Path) -> None:
+    result = _sample_result(tmp_path)
+    jsonl_path = tmp_path / "out.jsonl"
+    md_path = tmp_path / "summary.md"
+
+    write_jsonl([result], jsonl_path)
+    write_markdown([result], md_path)
+
+    data = jsonl_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(data) == 1
+    record = json.loads(data[0])
+    assert record["verdict"] == "fail"
+    assert record["matches"][0]["reference"].endswith("match.jpg")
+
+    markdown = md_path.read_text(encoding="utf-8")
+    assert "Image Similarity Checker Report" in markdown
+    assert "candidate.jpg" in markdown
+    assert "FAIL" in markdown


### PR DESCRIPTION
## Summary
- add a configurable image similarity checker app with embedding and perceptual hash strategies plus optional explanations
- provide a CLI, configuration defaults, reporting, and metadata support alongside documentation
- add targeted unit tests covering config resolution, engine behaviour, metadata writing, reporting, and CLI wiring

## Testing
- pytest tests/image_similarity -q

------
https://chatgpt.com/codex/tasks/task_e_68e61fe53328832297d75de23fd04fdc